### PR TITLE
fix: prevent blank page from displaying when error returned from async run function

### DIFF
--- a/src/components/account/lib/error-message.tsx
+++ b/src/components/account/lib/error-message.tsx
@@ -9,10 +9,12 @@ interface Props {
 }
 
 function FormErrorMessage({ error }: Props) {
+  const errorMsg = getErrorMessage(error)
+
   return (
     <div className={clsx(styles.formError, 'flex items-center')}>
       <ExclamationCircleIcon className="mr-2 h-10 w-10" />
-      <p>{getErrorMessage(error)}</p>
+      <p>{errorMsg}</p>
     </div>
   )
 }

--- a/src/components/loader/full-page-error-fallback.tsx
+++ b/src/components/loader/full-page-error-fallback.tsx
@@ -5,11 +5,13 @@ interface Props {
 }
 
 function FullPageErrorFallback({ error }: Props) {
+  const errorMsg = getErrorMessage(error)
+
   return (
     <div role="alert" className="flex h-screen flex-col items-center justify-center">
       <div>
         <p>Uh oh... There's a problem. Try refreshing the app.</p>
-        <pre>{getErrorMessage(error)}</pre>
+        <pre>{errorMsg}</pre>
       </div>
     </div>
   )

--- a/src/components/section/section.tsx
+++ b/src/components/section/section.tsx
@@ -26,8 +26,6 @@ function Section({ as, children, className, separator, separatorClass }: Props) 
     bottom: separator === 'bottom' || separator === 'top-bottom',
   }
 
-  console.log({ separatorClass })
-
   return (
     <Tag className={className}>
       <SectionWrapper>

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -141,10 +141,8 @@ function AuthProvider(props: AuthProviderProps) {
       const currentUser: AuthUser = auth.currentUser
 
       if (currentUser) {
-        console.log('reauthenticate: currentUser', currentUser)
         return currentUser.reauthenticateWithCredential(credential)
       } else {
-        console.log('reauthenticate: rejected currentUser', currentUser)
         return Promise.reject(new Error('No user is currently signed in.'))
       }
     },

--- a/src/hooks/async.tsx
+++ b/src/hooks/async.tsx
@@ -95,11 +95,9 @@ function useAsync<TData>(initialData: Nullable<TData> = null): AsyncValue<TData>
       return promise.then(
         (data: AsyncState<TData>['data']) => {
           setData(data)
-          return data
         },
         (error: AsyncState<TData>['error']) => {
           setError(error)
-          return Promise.reject(error)
         },
       )
     },

--- a/src/hooks/async.tsx
+++ b/src/hooks/async.tsx
@@ -15,6 +15,8 @@ interface AsyncState<TData = TUnknown> {
   status: AsyncActionType
 }
 
+type AsyncReducer<T> = (state: AsyncState<T>, action: AsyncAction<T>) => AsyncState<T>
+
 interface AsyncAction<TData> extends AsyncState<TData> {
   type: AsyncActionType
 }
@@ -63,19 +65,18 @@ function asyncReducer<TData>(state: AsyncState<TData>, action: AsyncAction<TData
 
 function useAsync<TData>(initialData: Nullable<TData> = null): AsyncValue<TData> {
   const initialState: AsyncState<TData> = {
-    status: AsyncActionType.IDLE,
     data: initialData,
     error: null,
+    status: AsyncActionType.IDLE,
   }
-  const [state, unsafeDispatch] = useReducer<
-    (state: AsyncState<TData>, action: AsyncAction<TData>) => AsyncState<TData>
-  >(asyncReducer, initialState)
+  const [state, unsafeDispatch] = useReducer<AsyncReducer<TData>>(asyncReducer, initialState)
   const dispatch = useSafeDispatch(unsafeDispatch)
 
   const setData = useCallback(
     (data: AsyncState<TData>['data']) => dispatch({ type: AsyncActionType.RESOLVED, data }),
     [dispatch],
   )
+
   const setError = useCallback(
     (error: AsyncState<TData>['error']) => dispatch({ type: AsyncActionType.REJECTED, error }),
     [dispatch],

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,9 +1,9 @@
-import type { HeadFC, PageProps } from 'gatsby'
+import type { HeadFC } from 'gatsby'
 
 import { Intro } from '~/components/intro'
 import { SEO } from '~/components/seo'
 
-function NotFoundPage({ location }: PageProps) {
+function NotFoundPage() {
   return (
     <Intro>
       <Intro.Title>Are you lost?</Intro.Title>

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,6 +1,6 @@
 // todo: Setup Firebase functionality to handle email and password updates onClick event handlers.
 import { navigate } from 'gatsby'
-import type { PageProps, HeadFC } from 'gatsby'
+import type { HeadFC } from 'gatsby'
 
 import { AccountMenu } from '~/components/account-menu'
 import { DeactivateAccountButton } from '~/components/account/deactivate-dialog'
@@ -11,7 +11,7 @@ import { SettingsEmailForm } from '~/components/account/settings-email-form'
 import { SettingsPasswordForm } from '~/components/account/settings-password-form'
 import { useAuth } from '~/context/auth'
 
-function AccountPage({ location }: PageProps) {
+function AccountPage() {
   const { isUser, profile, updateSettings } = useAuth()
 
   if (!isUser) {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,5 @@
 import { navigate } from 'gatsby'
-import type { PageProps, HeadFC } from 'gatsby'
+import type { HeadFC } from 'gatsby'
 
 import styles from '~/utils/styles/form'
 import { Link } from '~/components/link'
@@ -9,7 +9,7 @@ import { SEO } from '~/components/seo'
 import { Section } from '~/components/section'
 import { useAuth } from '~/context/auth'
 
-function LoginPage({ location }: PageProps) {
+function LoginPage() {
   const { login, isUser } = useAuth()
 
   if (isUser) {

--- a/src/pages/password/reset.tsx
+++ b/src/pages/password/reset.tsx
@@ -1,5 +1,5 @@
 // todo: this could probably use a basic email form with resetPassword as the onSubmit
-import type { HeadFC, PageProps } from 'gatsby'
+import type { HeadFC } from 'gatsby'
 
 import styles from '~/utils/styles/form'
 import { Link } from '~/components/link'
@@ -9,7 +9,7 @@ import { SEO } from '~/components/seo'
 import { Section } from '~/components/section'
 import { useAuth } from '~/context/auth'
 
-function ResetPassword({ location }: PageProps) {
+function ResetPassword() {
   const { resetPassword } = useAuth()
 
   return (

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -1,5 +1,5 @@
 import { navigate } from 'gatsby'
-import type { PageProps, HeadFC } from 'gatsby'
+import type { HeadFC } from 'gatsby'
 
 import styles from '~/utils/styles/form'
 import { Link } from '~/components/link'
@@ -9,7 +9,7 @@ import { SEO } from '~/components/seo'
 import { Section } from '~/components/section'
 import { useAuth } from '~/context/auth'
 
-function RegisterPage({ location }: PageProps) {
+function RegisterPage() {
   const { register, isUser } = useAuth()
 
   if (isUser) {


### PR DESCRIPTION
Error set during the run function would not display (or display momentarily) before the page would become blank with an uncaught error exception. This fixes that issue so that the returned error can be displayed.