### PR TITLE
fix: update React imports to use named imports instead of dot notation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,23 +1,23 @@
-import React from 'react'
+import { lazy, Suspense } from 'react'
 import type { PageProps } from 'gatsby'
 
 import { useAuth } from '~/context/auth'
 import { FullPageLogo } from '~/components/loader'
 
-const AuthenticatedApp = React.lazy(() => import(/* webpackPrefetch: true */ './authenticated-app'))
-const UnauthenticatedApp = React.lazy(() => import('./unauthenticated-app'))
+const AuthenticatedApp = lazy(() => import(/* webpackPrefetch: true */ './authenticated-app'))
+const UnauthenticatedApp = lazy(() => import('./unauthenticated-app'))
 
 function App({ children }: PageProps) {
   const { profile } = useAuth()
 
   return (
-    <React.Suspense fallback={<FullPageLogo />}>
+    <Suspense fallback={<FullPageLogo />}>
       {profile ? (
         <AuthenticatedApp>{children}</AuthenticatedApp>
       ) : (
         <UnauthenticatedApp>{children}</UnauthenticatedApp>
       )}
-    </React.Suspense>
+    </Suspense>
   )
 }
 

--- a/src/authenticated-app.tsx
+++ b/src/authenticated-app.tsx
@@ -1,11 +1,11 @@
 // todo: Consider moving UsersProvider around the areas that need it.
-import React from 'react'
+import type { ReactNode } from 'react'
 
 import { Layout } from '~/components/layout'
 import { UsersProvider } from '~/context/users'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 function AuthenticatedApp({ children }: Props) {

--- a/src/components/account/deactivate-form.tsx
+++ b/src/components/account/deactivate-form.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent, FormEvent } from 'react'
 import { useState } from 'react'
 import clsx from 'clsx'
 
@@ -18,13 +19,13 @@ function DeactivateForm({ buttonText = 'Submit', className, onSubmit }: Props) {
     password: '',
   })
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const { password } = state
     run(onSubmit({ password }))
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setState({ ...state, [event.target.id]: event.target.value })
   }
 

--- a/src/components/account/login-form.tsx
+++ b/src/components/account/login-form.tsx
@@ -1,7 +1,8 @@
 // todo: Use Formik
 // https://devdojo.com/semirteskeredzic/create-forms-with-formik-and-firebase
+import type { ChangeEvent, FormEvent } from 'react'
+import { useState } from 'react'
 import clsx from 'clsx'
-import React, { useState } from 'react'
 
 import { FormErrorMessage } from '~/components/account/lib/error-message'
 import styles from '~/utils/styles'
@@ -23,13 +24,13 @@ function LoginForm({ className, buttonText, onSubmit, hiddenFields = [] }: Login
     password: '',
   })
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const { email, password } = state
     run(onSubmit({ email, password }))
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setState({ ...state, [event.target.id]: event.target.value })
   }
 

--- a/src/components/affiliate/affiliate-disclosure.tsx
+++ b/src/components/affiliate/affiliate-disclosure.tsx
@@ -1,8 +1,9 @@
+import type { ReactNode } from 'react'
 import { useState } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   title: string
 }

--- a/src/components/card/card-icon.tsx
+++ b/src/components/card/card-icon.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react'
+import type { ComponentProps } from 'react'
+import { useMemo } from 'react'
 import clsx from 'clsx'
 import { CheckIcon, HeartIcon, StarIcon } from '@heroicons/react/20/solid'
 
@@ -11,7 +12,7 @@ interface Props {
 }
 
 interface CardIconItem {
-  icon: (props: React.ComponentProps<'svg'>) => JSX.Element
+  icon: (props: ComponentProps<'svg'>) => JSX.Element
   style: string
   title: string
   to: string

--- a/src/components/card/card-subtitle.tsx
+++ b/src/components/card/card-subtitle.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 import { sanitizeHTMLTag } from '~/utils/misc'
@@ -6,7 +6,7 @@ import type { TAny } from '~/utils/types/shared'
 
 interface Props {
   as: 'h2' | 'h3'
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/card/card-text.tsx
+++ b/src/components/card/card-text.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/card/card-title.tsx
+++ b/src/components/card/card-title.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 import { sanitizeHTMLTag } from '~/utils/misc'
@@ -6,7 +6,7 @@ import type { TAny } from '~/utils/types/shared'
 
 interface Props {
   as: 'h1' | 'h2' | 'h3'
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/card/card-wrapper.tsx
+++ b/src/components/card/card-wrapper.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { PropsWithChildren } from 'react'
 
 import CardContent from './card-content'
 import CardIcon from './card-icon'
@@ -10,7 +10,6 @@ import CardTitle from './card-title'
 import CardWrapper from './card-wrapper'
 
 interface Props {
-  children?: React.ReactNode
   className?: string
   icons?: string[]
   image: string
@@ -21,7 +20,17 @@ interface Props {
   to: string
 }
 
-function Card({ children, className, icons, image, imageAlt, subtitle, text, title, to }: Props) {
+function Card({
+  children,
+  className,
+  icons,
+  image,
+  imageAlt,
+  subtitle,
+  text,
+  title,
+  to,
+}: PropsWithChildren<Props>) {
   return (
     <CardWrapper className={className}>
       <CardImage alt={imageAlt} image={image} />

--- a/src/components/footer/widget/widget-title.tsx
+++ b/src/components/footer/widget/widget-title.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
+import type { PropsWithChildren } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children?: React.ReactNode
   className?: string
 }
 
-function WidgetTitle({ children, className }: Props) {
+function WidgetTitle({ children, className }: PropsWithChildren<Props>) {
   return (
     <h3 className={clsx('text-sm font-semibold uppercase tracking-wider text-gray-400', className)}>
       {children}

--- a/src/components/intro/intro-tagline.tsx
+++ b/src/components/intro/intro-tagline.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/intro/intro-title.tsx
+++ b/src/components/intro/intro-title.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   size?: 'large'
 }

--- a/src/components/intro/intro.tsx
+++ b/src/components/intro/intro.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { PropsWithChildren } from 'react'
 import clsx from 'clsx'
 import { GatsbyImage } from 'gatsby-plugin-image'
 
@@ -12,13 +12,19 @@ import IntroTitle from './intro-title'
 interface Props {
   align?: SectionContentProps['align']
   bgGradient?: boolean
-  children?: React.ReactNode
   className?: string
   fullscreen?: boolean
   image?: TAny // ImageComponentProps
 }
 
-function Intro({ align, bgGradient, children, className, fullscreen, image }: Props) {
+function Intro({
+  align,
+  bgGradient,
+  children,
+  className,
+  fullscreen,
+  image,
+}: PropsWithChildren<Props>) {
   const imageSrc =
     image?.childImageSharp?.gatsbyImageData ||
     image?.localFiles?.[0]?.childImageSharp?.gatsbyImageData

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import { Footer } from '~/components/footer'
 import { Header } from '~/components/header'
 import { useSiteMetadata } from '~/hooks/site-metadata'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 function Layout({ children }: Props) {

--- a/src/components/link/link-button.tsx
+++ b/src/components/link/link-button.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 import type { TAny } from '~/utils/types/shared'
 
 import Link from './link'
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   color?: keyof typeof colorClassMap
   size?: keyof typeof sizeClassMap

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import { Link as GatsbyLink } from 'gatsby'
 import type { TUnknown } from '~/utils/types/shared'
 
 import LinkButton from './link-button'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   to: string
   [key: string]: TUnknown
 }

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -1,9 +1,10 @@
-import React, { Fragment, useState } from 'react'
+import type { ComponentProps } from 'react'
+import { Fragment, useState } from 'react'
 import clsx from 'clsx'
 import { Transition } from '@headlessui/react'
 import { XMarkIcon as CloseIcon } from '@heroicons/react/24/solid'
 
-type IconProps = React.ComponentProps<'svg'> & {
+type IconProps = ComponentProps<'svg'> & {
   className?: string
 }
 

--- a/src/components/page/page-title.tsx
+++ b/src/components/page/page-title.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 
 import PageTitle from './page-title'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/profile-menu/profile-menu-item.tsx
+++ b/src/components/profile-menu/profile-menu-item.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType, ReactNode } from 'react'
 import { Menu } from '@headlessui/react'
 
 import type { StyleMenuItemArgs } from './utils'
@@ -6,12 +7,12 @@ import { getMenuItemStyles } from './utils'
 
 interface MenuItemTypeProps {
   active: boolean
-  children: React.ReactNode
+  children: ReactNode
 }
 
 interface Props {
   as?: StyleMenuItemArgs['type']
-  icon: React.ComponentType<{ className: string }>
+  icon: ComponentType<{ className: string }>
   onClick?: () => void
   title: string
   to: string

--- a/src/components/section/section-content.tsx
+++ b/src/components/section/section-content.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ElementType, ReactNode } from 'react'
 import clsx from 'clsx'
 
 import { sanitizeHTMLTag } from '~/utils/misc'
@@ -9,7 +9,7 @@ const allowedTags = ['div', 'article', 'footer', 'header', 'section'] as const
 export interface SectionContentProps {
   align?: typeof allowedAligns[number]
   as?: typeof allowedTags[number]
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
@@ -25,7 +25,7 @@ function mapAlignToClassName(align: SectionContentProps['align']) {
 
 function SectionContent({ align, as, children, className }: SectionContentProps) {
   const columns = mapAlignToClassName(align)
-  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as React.ElementType
+  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as ElementType
 
   return (
     <Tag className={clsx('py-6 sm:col-span-2 lg:py-16', columns?.start, columns?.span, className)}>

--- a/src/components/section/section-sidebar.tsx
+++ b/src/components/section/section-sidebar.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
   align?: 'left' | 'right'
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   isSticky?: boolean
 }

--- a/src/components/section/section-title.tsx
+++ b/src/components/section/section-title.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ElementType, ReactNode } from 'react'
 import clsx from 'clsx'
 
 import { sanitizeHTMLTag } from '~/utils/misc'
@@ -7,12 +7,12 @@ const allowedTags = ['h1', 'h2', 'h3'] as const
 
 interface Props {
   as?: typeof allowedTags[number]
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
 function SectionTitle({ as, children, className = '' }: Props) {
-  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as React.ElementType
+  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as ElementType
 
   return (
     <Tag

--- a/src/components/section/section-wrapper.tsx
+++ b/src/components/section/section-wrapper.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 

--- a/src/components/section/section.tsx
+++ b/src/components/section/section.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ElementType, ReactNode } from 'react'
 
 import SectionContent from './section-content'
 import SectionSeparator from './section-separator'
@@ -13,14 +13,14 @@ const allowedSeparators = ['top', 'bottom', 'top-bottom'] as const
 
 interface Props {
   as?: typeof allowedTags[number]
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   separator?: Nullable<typeof allowedSeparators[number]>
   separatorClass?: string
 }
 
 function Section({ as, children, className, separator, separatorClass }: Props) {
-  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as React.ElementType
+  const Tag = sanitizeHTMLTag(as, Array.from(allowedTags)) as ElementType
   const border = {
     top: separator === 'top' || separator === 'top-bottom',
     bottom: separator === 'bottom' || separator === 'top-bottom',

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ChangeEvent, ReactNode } from 'react'
 import { navigate } from 'gatsby'
 import clsx from 'clsx'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
@@ -12,7 +12,7 @@ export interface SelectOption {
 }
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   current?: SelectOption
   label?: string
@@ -39,7 +39,7 @@ function Select({ children, className, current, label }: Props) {
               as="select"
               name="optionPath"
               className="flex-grow cursor-pointer border-0 bg-transparent bg-none p-0"
-              onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 handleChange(event)
                 submitForm()
               }}

--- a/src/components/seo/seo.tsx
+++ b/src/components/seo/seo.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { PropsWithChildren } from 'react'
 import type { HeadProps } from 'gatsby'
 import striptags from 'striptags'
 
@@ -8,14 +8,13 @@ import { trimText } from '~/utils/misc'
 const BASE_URL = process.env.BASE_URL ?? 'https://gettreadtalks.com'
 
 interface Props {
-  children?: ReactNode
   description?: string | null
   image?: string
   location: HeadProps['location']
   title?: string | null
 }
 
-function SEO({ children, description, image, location, title }: Props) {
+function SEO({ children, description, image, location, title }: PropsWithChildren<Props>) {
   const { title: siteTitle, description: siteDescription } = useSiteMetadata()
 
   const seo = {

--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -1,5 +1,5 @@
-import type { FormEvent } from 'react'
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import type { FormEvent, ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 import clsx from 'clsx'
 import { Switch } from '@headlessui/react'
 
@@ -7,7 +7,7 @@ import { callAll } from '~/utils/misc'
 import type { TAny } from '~/utils/types/shared'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 interface GetToggleProps {
@@ -57,7 +57,7 @@ function ToggleButton({
   ...props
 }: {
   checked: boolean
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   onChange?: GetToggleProps['onChange']
 }) {

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,11 +1,13 @@
 // todo: Consider moving AuthProvider around the areas that need it. Notably the account navigation dropdown, account screens, and user action buttons on talk pages.
+import type { ReactNode } from 'react'
+
 import { AuthProvider } from '~/context/auth'
 import { ErrorBoundary } from '~/components/error-boundary'
 import { FirebaseProvider } from '~/context/firebase'
 import { NotificationProvider } from '~/context/notifications'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 function AppProviders({ children }: Props) {

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useCallback, useContext, useReducer } from 'react'
+import type { Dispatch, ReactNode } from 'react'
+import { createContext, useCallback, useContext, useReducer } from 'react'
 
 import { Notification } from '~/components/notification'
 import type { NotificationMessage } from '~/components/notification/notification'
@@ -20,11 +21,11 @@ interface NotificationAction {
 }
 
 interface NotificationProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export interface NotificationContextValue {
-  dispatch: React.Dispatch<NotificationAction>
+  dispatch: Dispatch<NotificationAction>
   notify: (message: NotificationMessage) => void
   state: NotificationState
 }

--- a/src/context/users.tsx
+++ b/src/context/users.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useCallback, useContext, useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect } from 'react'
 import type { DocumentData, SetOptions } from 'firebase/firestore'
 import { deleteDoc, doc, getDoc, getFirestore, setDoc, updateDoc } from 'firebase/firestore'
 
@@ -17,7 +18,7 @@ interface User {
 }
 
 interface UsersProviderProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export interface UsersProviderValue {

--- a/src/hooks/safeDispatch.tsx
+++ b/src/hooks/safeDispatch.tsx
@@ -1,7 +1,9 @@
+import type { Dispatch } from 'react'
 import { useCallback, useLayoutEffect, useRef } from 'react'
+
 import type { TAny } from '~/utils/types/shared'
 
-function useSafeDispatch(dispatch: React.Dispatch<TAny>) {
+function useSafeDispatch(dispatch: Dispatch<TAny>) {
   const mounted = useRef(false)
 
   useLayoutEffect(() => {

--- a/src/unauthenticated-app.tsx
+++ b/src/unauthenticated-app.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 
 import { Layout } from '~/components/layout'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 function UnauthenticatedApp({ children }: Props) {

--- a/src/utils/types/shared.ts
+++ b/src/utils/types/shared.ts
@@ -1,3 +1,5 @@
+import type { ComponentProps } from 'react'
+
 // Todo: Remove all uses of this type and replace with the correct type
 export type TAny = any
 // Todo: Remove all uses of this type and replace with the correct type
@@ -8,7 +10,7 @@ export type Nullable<T> = T | null | undefined
 export interface NavigationItem {
   name: string
   to: string
-  icon?: (props: React.ComponentProps<'svg'>) => JSX.Element
+  icon?: (props: ComponentProps<'svg'>) => JSX.Element
 }
 
 export interface TLink {


### PR DESCRIPTION
Experimenting with being consistent with named imports from React, including types, instead of using dot notation.